### PR TITLE
Support zsh and deactivate when leaving environment directories (delete me)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This functionality was inspired by [conda auto activate](https://github.com/sott
 
 ## Install
 
-To install add this line to your .bashrc or .bash-profile:
+To install add this line to your .bashrc, .bash-profile, or .zshrc:
 
        source /path/to/conda_auto_env.sh
 

--- a/conda_auto_env.sh
+++ b/conda_auto_env.sh
@@ -17,8 +17,10 @@ function conda_auto_env() {
     ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
     # Check if you are already in the environment
     if [[ $PATH != */envs/*$ENV*/* ]]; then
-      # Check if the environment exists
+      # Attempt to activate environment
+      CONDA_ENVIRONMENT_ROOT="" #For spawned shells
       source activate $ENV
+      CONDA_ENVIRONMENT_ROOT="$(pwd)"
       if [ $? -eq 0 ]; then
         :
       else
@@ -28,6 +30,12 @@ function conda_auto_env() {
         source activate $ENV
       fi
     fi
+  elif [[ $PATH = */envs/* ]]\
+    && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT ]]\
+    && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT/* ]]
+  then
+    CONDA_ENVIRONMENT_ROOT=""
+    source deactivate
   fi
 }
 

--- a/conda_auto_env.sh
+++ b/conda_auto_env.sh
@@ -15,21 +15,23 @@ function conda_auto_env() {
   if [ -e "environment.yml" ]; then
     # echo "environment.yml file found"
     ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
-    # Check if you are already in the environment
+    # Check if the environment is already active.
     if [[ $PATH != */envs/*$ENV*/* ]]; then
-      # Attempt to activate environment
+      # Attempt to activate environment.
       CONDA_ENVIRONMENT_ROOT="" #For spawned shells
       source activate $ENV
+      # Set root directory of active environment.
       CONDA_ENVIRONMENT_ROOT="$(pwd)"
       if [ $? -eq 0 ]; then
         :
       else
-        # Create the environment and activate
-        echo "Conda env '$ENV' doesn't exist."
+        # Create the environment and activate.
+        echo "Conda environment '$ENV' doesn't exist: Creating."
         conda env create -q
         source activate $ENV
       fi
     fi
+  # Deactivate active environment if we are no longer among its subdirectories.
   elif [[ $PATH = */envs/* ]]\
     && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT ]]\
     && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT/* ]]

--- a/conda_auto_env.sh
+++ b/conda_auto_env.sh
@@ -6,7 +6,7 @@
 # If the environment doesn't exist, conda-auto-env creates it and
 # activates it for you.
 #
-# To install add this line to your .bashrc or .bash-profile:
+# To install add this line to your .bashrc, .bash-profile, or .zshrc:
 #
 #       source /path/to/conda_auto_env.sh
 #
@@ -39,4 +39,16 @@ function conda_auto_env() {
   fi
 }
 
-export PROMPT_COMMAND=conda_auto_env
+# Check active shell.
+if [[ $(ps -p$$ -ocmd=) == "zsh" ]]; then
+  # For zsh, use the chpwd hook.
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd conda_auto_env
+  # Run for present directory as it does not fire the above hook.
+  conda_auto_env
+  # More aggressive option in case the above hook misses some use case:
+  #precmd() { conda_auto_env; }
+else
+  # For bash, no hooks and we rely on the env. var. PROMPT_COMMAND:
+  export PROMPT_COMMAND=conda_auto_env
+fi

--- a/conda_auto_env.sh
+++ b/conda_auto_env.sh
@@ -22,9 +22,7 @@ function conda_auto_env() {
       source activate $ENV
       # Set root directory of active environment.
       CONDA_ENVIRONMENT_ROOT="$(pwd)"
-      if [ $? -eq 0 ]; then
-        :
-      else
+      if [ $? -ne 0 ]; then
         # Create the environment and activate.
         echo "Conda environment '$ENV' doesn't exist: Creating."
         conda env create -q

--- a/conda_auto_env_remote.sh
+++ b/conda_auto_env_remote.sh
@@ -19,7 +19,7 @@ function conda_auto_env_remote() {
     # echo "environment.yml file found"
     ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
     # Check if you are already in the environment
-    if [[ $PATH != *$ENV* ]]; then
+    if [[ $PATH != */envs/*$ENV*/* ]]; then
       # Check if the environment exists
       source activate $ENV
       if [ $? -eq 0 ]; then
@@ -37,7 +37,7 @@ function conda_auto_env_remote() {
     ENV=$(sed -n '1p' environment-remote.yml | cut -f2 -d ' ')
     CHANNEL=$(sed -n '2p' environment-remote.yml | cut -f2 -d ' ')
     # Check if you are already in the environment
-    if [[ $PATH != *$ENV* ]]; then
+    if [[ $PATH != */envs/*$ENV*/* ]]; then
       # Check if the environment exists
       source activate $ENV
       if [ $? -eq 0 ]; then

--- a/conda_auto_env_remote.sh
+++ b/conda_auto_env_remote.sh
@@ -25,9 +25,7 @@ function conda_auto_env_remote() {
       source activate $ENV
       # Set root directory of active environment.
       CONDA_ENVIRONMENT_ROOT="$(pwd)"
-      if [ $? -eq 0 ]; then
-        :
-      else
+      if [ $? -ne 0 ]; then
         # Create the environment and activate.
         echo "Conda environment '$ENV' doesn't exist: Creating."
         conda env create -q
@@ -46,9 +44,7 @@ function conda_auto_env_remote() {
       source activate $ENV
       # Set root directory of active environment.
       CONDA_ENVIRONMENT_ROOT="$(pwd)"
-      if [ $? -eq 0 ]; then
-        :
-      else
+      if [ $? -ne 0 ]; then
         # Create the environment and activate.
         echo "Conda env '$ENV' doesn't exist."
         REMOTE=$CHANNEL'/'$ENV

--- a/conda_auto_env_remote.sh
+++ b/conda_auto_env_remote.sh
@@ -63,4 +63,16 @@ function conda_auto_env_remote() {
   fi
 }
 
-export PROMPT_COMMAND=conda_auto_env_remote
+# Check active shell.
+if [[ $(ps -p$$ -ocmd=) == "zsh" ]]; then
+  # For zsh, use the chpwd hook.
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd conda_auto_env
+  # Run for present directory as it does not fire the above hook.
+  conda_auto_env
+  # More aggressive option in case the above hook misses some use case:
+  #precmd() { conda_auto_env; }
+else
+  # For bash, no hooks and we rely on the env. var. PROMPT_COMMAND:
+  export PROMPT_COMMAND=conda_auto_env
+fi

--- a/conda_auto_env_remote.sh
+++ b/conda_auto_env_remote.sh
@@ -18,17 +18,18 @@ function conda_auto_env_remote() {
   if [ -e "environment.yml" ]; then
     # echo "environment.yml file found"
     ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
-    # Check if you are already in the environment
+    # Check if the environment is already active.
     if [[ $PATH != */envs/*$ENV*/* ]]; then
-      # Attempt to activate environment
+      # Attempt to activate environment.
       CONDA_ENVIRONMENT_ROOT="" #For spawned shells
       source activate $ENV
+      # Set root directory of active environment.
       CONDA_ENVIRONMENT_ROOT="$(pwd)"
       if [ $? -eq 0 ]; then
         :
       else
-        # Create the environment and activate
-        echo "Conda env '$ENV' doesn't exist."
+        # Create the environment and activate.
+        echo "Conda environment '$ENV' doesn't exist: Creating."
         conda env create -q
         source activate $ENV
       fi
@@ -38,16 +39,17 @@ function conda_auto_env_remote() {
     # echo "environment.yml file found"
     ENV=$(sed -n '1p' environment-remote.yml | cut -f2 -d ' ')
     CHANNEL=$(sed -n '2p' environment-remote.yml | cut -f2 -d ' ')
-    # Check if you are already in the environment
+    # Check if the environment is already active.
     if [[ $PATH != */envs/*$ENV*/* ]]; then
-      # Attempt to activate environment
+      # Attempt to activate environment.
       CONDA_ENVIRONMENT_ROOT="" #For spawned shells
       source activate $ENV
+      # Set root directory of active environment.
       CONDA_ENVIRONMENT_ROOT="$(pwd)"
       if [ $? -eq 0 ]; then
         :
       else
-        # Create the environment and activate
+        # Create the environment and activate.
         echo "Conda env '$ENV' doesn't exist."
         REMOTE=$CHANNEL'/'$ENV
         conda env create $REMOTE -q
@@ -55,6 +57,7 @@ function conda_auto_env_remote() {
       fi
     fi
   fi
+  # Deactivate active environment if we are no longer among its subdirectories.
   if [[ $PATH = */envs/* ]]\
     && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT ]]\
     && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT/* ]]

--- a/conda_auto_env_remote.sh
+++ b/conda_auto_env_remote.sh
@@ -20,8 +20,10 @@ function conda_auto_env_remote() {
     ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
     # Check if you are already in the environment
     if [[ $PATH != */envs/*$ENV*/* ]]; then
-      # Check if the environment exists
+      # Attempt to activate environment
+      CONDA_ENVIRONMENT_ROOT="" #For spawned shells
       source activate $ENV
+      CONDA_ENVIRONMENT_ROOT="$(pwd)"
       if [ $? -eq 0 ]; then
         :
       else
@@ -38,8 +40,10 @@ function conda_auto_env_remote() {
     CHANNEL=$(sed -n '2p' environment-remote.yml | cut -f2 -d ' ')
     # Check if you are already in the environment
     if [[ $PATH != */envs/*$ENV*/* ]]; then
-      # Check if the environment exists
+      # Attempt to activate environment
+      CONDA_ENVIRONMENT_ROOT="" #For spawned shells
       source activate $ENV
+      CONDA_ENVIRONMENT_ROOT="$(pwd)"
       if [ $? -eq 0 ]; then
         :
       else
@@ -50,6 +54,13 @@ function conda_auto_env_remote() {
         source activate $ENV
       fi
     fi
+  fi
+  if [[ $PATH = */envs/* ]]\
+    && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT ]]\
+    && [[ $(pwd) != $CONDA_ENVIRONMENT_ROOT/* ]]
+  then
+    CONDA_ENVIRONMENT_ROOT=""
+    source deactivate
   fi
 }
 

--- a/tmp.sh
+++ b/tmp.sh
@@ -12,11 +12,31 @@
 #
 
 function conda_auto_env() {
+  if [ -e "env.yml" ]; then
+    #echo "env.yml file found"
+    ENV=$(head -n 1 env.yml | cut -f2 -d ' ')
+    # Check if you are already in the environment
+    #echo $ENV
+    if [[ $PATH != *$ENV* ]]; then
+      # Check if the environment exists
+      #echo $ENV
+      source activate $ENV
+      if [ $? -eq 0 ]; then
+        echo "activated"
+        :
+      else
+        # Create the environment and activate
+        echo "Conda env '$ENV' doesn't exist."
+        conda env create -q
+        source activate $ENV
+      fi
+    fi
+  fi
   if [ -e "environment.yml" ]; then
     # echo "environment.yml file found"
     ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
     # Check if you are already in the environment
-    if [[ $PATH != */envs/*$ENV*/* ]]; then
+    if [[ $PATH != *$ENV* ]]; then
       # Check if the environment exists
       source activate $ENV
       if [ $? -eq 0 ]; then
@@ -31,4 +51,9 @@ function conda_auto_env() {
   fi
 }
 
-export PROMPT_COMMAND=conda_auto_env
+if [ $(ps -p$$ -ocmd=) "=" "zsh" ]
+then
+  precmd() { conda_auto_env; }
+else
+  export PROMPT_COMMAND=conda_auto_env
+fi


### PR DESCRIPTION
Closed in favor of a new pull request without the extraneous file.

Apologies.

---

Hi!
The `conda-auto-env` script is really handy but I missed two features, here added:
- Support for `zsh`.
- Deactivating environments when leaving their directories.
  Also included some minor inconsequential changes to code and comments.

I hope these minor changes will be accepted.
### zshell

Easybird gave an easy solution for modifying `.zshrc` to support the script but it is better if the script works with just `source` (and addresses some minor issues). At least, for me, I missed the comment and spent time on finding a workaround. The modification simply checks the active shell and hooks `zsh` differently.
### Deactivating environments

When working, often one will jump around between directories and this introduces the issue that whatever environment one was working with last sticks in the terminal. E.g., if one's default/root Conda environment has different versions or packages, these will be not be available after having entered a project directory. This behavior also persists to new tabs in a terminal. A simple work-around was to deactivate the current environment, in favor of the default, when no longer in a subdirectory of the directory that an environment was activated in.
